### PR TITLE
Add PDF conversion workflow with templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+uploads/
+outputs/
+stored_templates/
+data/storage.json
+.env
+instance/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,329 @@
+import json
+import shutil
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any, List
+
+from flask import (
+    Flask,
+    jsonify,
+    render_template,
+    request,
+    send_from_directory,
+)
+from werkzeug.utils import secure_filename
+
+from converters import convert_file_to_pdf, UnsupportedFileType
+
+BASE_DIR = Path(__file__).resolve().parent
+UPLOAD_DIR = BASE_DIR / "uploads"
+OUTPUT_DIR = BASE_DIR / "outputs"
+TEMPLATE_STORAGE_DIR = BASE_DIR / "stored_templates"
+DATA_DIR = BASE_DIR / "data"
+DATA_FILE = DATA_DIR / "storage.json"
+
+for directory in (UPLOAD_DIR, OUTPUT_DIR, TEMPLATE_STORAGE_DIR, DATA_DIR):
+    directory.mkdir(parents=True, exist_ok=True)
+
+app = Flask(__name__)
+
+
+def load_storage() -> Dict[str, List[Dict[str, Any]]]:
+    if DATA_FILE.exists():
+        try:
+            with DATA_FILE.open("r", encoding="utf-8") as fp:
+                data = json.load(fp)
+                return {
+                    "history": data.get("history", []),
+                    "templates": data.get("templates", []),
+                }
+        except json.JSONDecodeError:
+            pass
+    return {"history": [], "templates": []}
+
+
+def save_storage(data: Dict[str, List[Dict[str, Any]]]) -> None:
+    with DATA_FILE.open("w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False, indent=2)
+
+
+def find_history_entry(data: Dict[str, List[Dict[str, Any]]], history_id: str) -> Dict[str, Any]:
+    for entry in data["history"]:
+        if entry["id"] == history_id:
+            return entry
+    return {}
+
+
+def find_template_entry(data: Dict[str, List[Dict[str, Any]]], template_id: str) -> Dict[str, Any]:
+    for entry in data["templates"]:
+        if entry["id"] == template_id:
+            return entry
+    return {}
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/upload", methods=["POST"])
+def upload_file():
+    if "file" not in request.files:
+        return jsonify({"error": "未找到上传文件"}), 400
+
+    file = request.files["file"]
+    if not file or file.filename == "":
+        return jsonify({"error": "请选择一个文件"}), 400
+
+    filename = secure_filename(file.filename)
+    history_id = str(uuid.uuid4())
+    stored_name = f"{history_id}_{filename}"
+    save_path = UPLOAD_DIR / stored_name
+    file.save(save_path)
+
+    storage = load_storage()
+    entry = {
+        "id": history_id,
+        "filename": filename,
+        "stored_name": stored_name,
+        "original_path": str(save_path.relative_to(BASE_DIR)),
+        "status": "uploaded",
+        "uploaded_at": datetime.utcnow().isoformat() + "Z",
+        "pdf_path": None,
+        "converted_at": None,
+    }
+    storage["history"].append(entry)
+    save_storage(storage)
+
+    return jsonify(_decorate_history_entry(entry))
+
+
+@app.route("/api/convert", methods=["POST"])
+def convert_history_item():
+    payload = request.get_json(force=True, silent=True)
+    if not payload or "history_id" not in payload:
+        return jsonify({"error": "缺少history_id"}), 400
+
+    history_id = payload["history_id"]
+    storage = load_storage()
+    entry = find_history_entry(storage, history_id)
+    if not entry:
+        return jsonify({"error": "未找到对应的历史记录"}), 404
+
+    if entry.get("status") == "converted" and entry.get("pdf_path"):
+        return jsonify(_decorate_history_entry(entry))
+
+    source_path = BASE_DIR / entry["original_path"]
+    if not source_path.exists():
+        return jsonify({"error": "原始文件不存在，无法转换"}), 404
+
+    original_stem = Path(entry["filename"]).stem
+    pdf_filename = f"{original_stem}_{history_id}.pdf"
+    output_path = OUTPUT_DIR / pdf_filename
+
+    try:
+        convert_file_to_pdf(source_path, output_path)
+    except UnsupportedFileType as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:  # pylint: disable=broad-except
+        return jsonify({"error": f"转换失败: {exc}"}), 500
+
+    entry["status"] = "converted"
+    entry["pdf_path"] = str(output_path.relative_to(BASE_DIR))
+    entry["converted_at"] = datetime.utcnow().isoformat() + "Z"
+    save_storage(storage)
+
+    return jsonify(_decorate_history_entry(entry))
+
+
+@app.route("/api/history", methods=["GET"])
+def list_history():
+    storage = load_storage()
+    history = [_decorate_history_entry(item) for item in storage["history"]]
+    history.sort(key=lambda item: item.get("uploaded_at", ""), reverse=True)
+    return jsonify(history)
+
+
+@app.route("/api/history/<history_id>", methods=["DELETE"])
+def delete_history(history_id: str):
+    storage = load_storage()
+    entry = find_history_entry(storage, history_id)
+    if not entry:
+        return jsonify({"error": "记录不存在"}), 404
+
+    storage["history"] = [item for item in storage["history"] if item["id"] != history_id]
+
+    original_path = BASE_DIR / entry["original_path"]
+    if original_path.exists():
+        original_path.unlink()
+
+    pdf_path = entry.get("pdf_path")
+    if pdf_path:
+        pdf_full_path = BASE_DIR / pdf_path
+        if pdf_full_path.exists():
+            pdf_full_path.unlink()
+
+    related_templates = [tpl for tpl in storage["templates"] if tpl.get("source_history_id") == history_id]
+    for template in related_templates:
+        _remove_template_files(template)
+    storage["templates"] = [tpl for tpl in storage["templates"] if tpl.get("source_history_id") != history_id]
+
+    save_storage(storage)
+    return jsonify({"message": "删除成功"})
+
+
+@app.route("/download/<history_id>", methods=["GET"])
+def download_pdf(history_id: str):
+    storage = load_storage()
+    entry = find_history_entry(storage, history_id)
+    if not entry or entry.get("status") != "converted" or not entry.get("pdf_path"):
+        return jsonify({"error": "文件不可下载"}), 404
+
+    pdf_path = BASE_DIR / entry["pdf_path"]
+    if not pdf_path.exists():
+        return jsonify({"error": "文件不存在"}), 404
+
+    return send_from_directory(pdf_path.parent, pdf_path.name, as_attachment=True)
+
+
+@app.route("/api/templates", methods=["GET"])
+def list_templates():
+    storage = load_storage()
+    templates = [
+        {
+            **template,
+            "download_url": f"/template-download/{template['id']}"
+            if template.get("stored_path")
+            else None,
+        }
+        for template in storage["templates"]
+    ]
+    templates.sort(key=lambda item: item.get("created_at", ""), reverse=True)
+    return jsonify(templates)
+
+
+@app.route("/api/templates", methods=["POST"])
+def create_template():
+    payload = request.get_json(force=True, silent=True)
+    if not payload or "history_id" not in payload:
+        return jsonify({"error": "缺少history_id"}), 400
+
+    history_id = payload["history_id"]
+    name = payload.get("name")
+
+    storage = load_storage()
+    entry = find_history_entry(storage, history_id)
+    if not entry:
+        return jsonify({"error": "历史记录不存在"}), 404
+
+    source_path = BASE_DIR / entry["original_path"]
+    if not source_path.exists():
+        return jsonify({"error": "源文件缺失，无法创建模板"}), 404
+
+    template_id = str(uuid.uuid4())
+    template_filename = f"{template_id}_{Path(entry['filename']).name}"
+    stored_path = TEMPLATE_STORAGE_DIR / template_filename
+    shutil.copy2(source_path, stored_path)
+
+    template_entry = {
+        "id": template_id,
+        "name": name or entry["filename"],
+        "filename": entry["filename"],
+        "stored_path": str(stored_path.relative_to(BASE_DIR)),
+        "source_history_id": history_id,
+        "created_at": datetime.utcnow().isoformat() + "Z",
+    }
+
+    storage["templates"].append(template_entry)
+    save_storage(storage)
+
+    template_entry["download_url"] = f"/template-download/{template_id}"
+    return jsonify(template_entry)
+
+
+@app.route("/api/templates/<template_id>", methods=["DELETE"])
+def delete_template(template_id: str):
+    storage = load_storage()
+    template = find_template_entry(storage, template_id)
+    if not template:
+        return jsonify({"error": "模板不存在"}), 404
+
+    _remove_template_files(template)
+    storage["templates"] = [tpl for tpl in storage["templates"] if tpl["id"] != template_id]
+    save_storage(storage)
+
+    return jsonify({"message": "模板已删除"})
+
+
+@app.route("/api/templates/<template_id>/use", methods=["POST"])
+def use_template(template_id: str):
+    payload = request.get_json(force=True, silent=True) or {}
+    new_name = payload.get("name")
+
+    storage = load_storage()
+    template = find_template_entry(storage, template_id)
+    if not template:
+        return jsonify({"error": "模板不存在"}), 404
+
+    template_path = BASE_DIR / template["stored_path"]
+    if not template_path.exists():
+        return jsonify({"error": "模板文件缺失"}), 404
+
+    history_id = str(uuid.uuid4())
+    filename = new_name or template["filename"]
+    stored_name = f"{history_id}_{secure_filename(filename)}"
+    destination = UPLOAD_DIR / stored_name
+    shutil.copy2(template_path, destination)
+
+    history_entry = {
+        "id": history_id,
+        "filename": filename,
+        "stored_name": stored_name,
+        "original_path": str(destination.relative_to(BASE_DIR)),
+        "status": "uploaded",
+        "uploaded_at": datetime.utcnow().isoformat() + "Z",
+        "pdf_path": None,
+        "converted_at": None,
+        "template_origin": template_id,
+    }
+
+    storage["history"].append(history_entry)
+    save_storage(storage)
+
+    return jsonify(_decorate_history_entry(history_entry))
+
+
+@app.route("/template-download/<template_id>", methods=["GET"])
+def download_template(template_id: str):
+    storage = load_storage()
+    template = find_template_entry(storage, template_id)
+    if not template or not template.get("stored_path"):
+        return jsonify({"error": "模板不可下载"}), 404
+
+    template_path = BASE_DIR / template["stored_path"]
+    if not template_path.exists():
+        return jsonify({"error": "模板文件不存在"}), 404
+
+    return send_from_directory(template_path.parent, template_path.name, as_attachment=True)
+
+
+def _decorate_history_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    decorated = dict(entry)
+    if entry.get("pdf_path"):
+        decorated["download_url"] = f"/download/{entry['id']}"
+    else:
+        decorated["download_url"] = None
+    return decorated
+
+
+def _remove_template_files(template: Dict[str, Any]) -> None:
+    stored_path = template.get("stored_path")
+    if stored_path:
+        template_file = BASE_DIR / stored_path
+        if template_file.exists():
+            template_file.unlink()
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=5000)

--- a/converters.py
+++ b/converters.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from fpdf import FPDF
+from openpyxl import load_workbook
+from pptx import Presentation
+from docx import Document
+
+
+class UnsupportedFileType(Exception):
+    """Raised when a file type cannot be converted to PDF."""
+
+
+ALLOWED_EXTENSIONS: Sequence[str] = (
+    ".docx",
+    ".xlsx",
+    ".xlsm",
+    ".pptx",
+    ".txt",
+    ".csv",
+)
+
+
+def convert_file_to_pdf(source_path: Path, output_path: Path) -> None:
+    extension = source_path.suffix.lower()
+    if extension not in ALLOWED_EXTENSIONS:
+        raise UnsupportedFileType("暂不支持该文件类型的PDF转换")
+
+    if extension == ".docx":
+        _convert_docx_to_pdf(source_path, output_path)
+    elif extension in {".xlsx", ".xlsm"}:
+        _convert_excel_to_pdf(source_path, output_path)
+    elif extension == ".pptx":
+        _convert_pptx_to_pdf(source_path, output_path)
+    elif extension == ".txt":
+        _convert_text_to_pdf(source_path, output_path)
+    elif extension == ".csv":
+        _convert_csv_to_pdf(source_path, output_path)
+    else:
+        raise UnsupportedFileType("暂不支持该文件类型的PDF转换")
+
+
+def _base_pdf(title: str | None = None) -> FPDF:
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    if title:
+        pdf.set_font("Arial", "B", 16)
+        pdf.multi_cell(0, 12, title)
+        pdf.ln(4)
+        pdf.set_font("Arial", size=12)
+    return pdf
+
+
+def _convert_docx_to_pdf(source_path: Path, output_path: Path) -> None:
+    document = Document(source_path)
+    pdf = _base_pdf(title=source_path.stem)
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        pdf.multi_cell(0, 8, text or " ")
+
+    pdf.output(str(output_path))
+
+
+def _convert_excel_to_pdf(source_path: Path, output_path: Path) -> None:
+    workbook = load_workbook(source_path, data_only=True, read_only=True)
+    pdf = _base_pdf(title=source_path.stem)
+
+    for worksheet in workbook.worksheets:
+        pdf.set_font("Arial", "B", 14)
+        pdf.multi_cell(0, 10, f"工作表: {worksheet.title}")
+        pdf.set_font("Arial", size=11)
+        for row in worksheet.iter_rows(values_only=True):
+            pdf.multi_cell(0, 7, _format_row(row))
+        pdf.ln(5)
+        pdf.set_font("Arial", size=12)
+
+    pdf.output(str(output_path))
+
+
+def _convert_pptx_to_pdf(source_path: Path, output_path: Path) -> None:
+    presentation = Presentation(source_path)
+    pdf = _base_pdf(title=source_path.stem)
+
+    for index, slide in enumerate(presentation.slides, start=1):
+        if index > 1:
+            pdf.add_page()
+        pdf.set_font("Arial", "B", 14)
+        pdf.multi_cell(0, 10, f"幻灯片 {index}")
+        pdf.set_font("Arial", size=12)
+        lines = _extract_slide_text(slide)
+        if not lines:
+            pdf.multi_cell(0, 8, "(此页暂无文本内容)")
+        for line in lines:
+            pdf.multi_cell(0, 8, line)
+
+    pdf.output(str(output_path))
+
+
+def _convert_text_to_pdf(source_path: Path, output_path: Path) -> None:
+    pdf = _base_pdf(title=source_path.stem)
+    with source_path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            pdf.multi_cell(0, 8, line.rstrip() or " ")
+    pdf.output(str(output_path))
+
+
+def _convert_csv_to_pdf(source_path: Path, output_path: Path) -> None:
+    pdf = _base_pdf(title=source_path.stem)
+    with source_path.open("r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            pdf.multi_cell(0, 8, line.rstrip())
+    pdf.output(str(output_path))
+
+
+def _format_row(row: Iterable) -> str:
+    values = ["" if cell is None else str(cell) for cell in row]
+    return " | ".join(values).strip() or " "
+
+
+def _extract_slide_text(slide) -> list[str]:
+    lines: list[str] = []
+    for shape in slide.shapes:
+        if not hasattr(shape, "text"):
+            continue
+        text = shape.text.strip()
+        if text:
+            lines.extend(part for part in text.splitlines() if part.strip())
+    return lines

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask==3.0.0
+python-docx==0.8.11
+openpyxl==3.1.2
+fpdf2==2.7.9
+python-pptx==0.6.21

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,314 @@
+const fileInput = document.getElementById('fileInput');
+const uploadBtn = document.getElementById('uploadBtn');
+const generateBtn = document.getElementById('generateBtn');
+const historyBody = document.getElementById('historyBody');
+const historyRowTemplate = document.getElementById('historyRowTemplate');
+const historyCount = document.getElementById('historyCount');
+const templateList = document.getElementById('templateList');
+const templateItemTemplate = document.getElementById('templateItemTemplate');
+const templateCount = document.getElementById('templateCount');
+const toast = document.getElementById('toast');
+
+let historyRecords = [];
+let templateRecords = [];
+let selectedHistoryId = null;
+
+async function init() {
+  await Promise.all([refreshHistory(), refreshTemplates()]);
+  bindEvents();
+}
+
+function bindEvents() {
+  uploadBtn.addEventListener('click', handleUpload);
+  generateBtn.addEventListener('click', handleGenerate);
+}
+
+async function handleUpload() {
+  if (!fileInput.files || fileInput.files.length === 0) {
+    showToast('请先选择一个文件');
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append('file', fileInput.files[0]);
+
+  toggleUploadButtons(true);
+  try {
+    const response = await fetch('/api/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.error || '上传失败');
+    }
+    showToast('上传成功');
+    fileInput.value = '';
+    await refreshHistory();
+    selectedHistoryId = result.id;
+    highlightSelected();
+  } catch (error) {
+    console.error(error);
+    showToast(error.message);
+  } finally {
+    toggleUploadButtons(false);
+  }
+}
+
+async function handleGenerate() {
+  const targetId = selectedHistoryId || historyRecords.find((item) => item.status !== 'converted')?.id;
+  if (!targetId) {
+    showToast('请先选择需要生成PDF的文件');
+    return;
+  }
+  await convertHistory(targetId);
+}
+
+async function convertHistory(historyId) {
+  try {
+    const response = await fetch('/api/convert', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ history_id: historyId }),
+    });
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.error || '转换失败');
+    }
+    showToast('PDF生成成功');
+    await refreshHistory();
+    selectedHistoryId = historyId;
+    highlightSelected();
+  } catch (error) {
+    console.error(error);
+    showToast(error.message);
+  }
+}
+
+async function refreshHistory() {
+  const response = await fetch('/api/history');
+  historyRecords = await response.json();
+  renderHistory();
+}
+
+function renderHistory() {
+  historyBody.innerHTML = '';
+  historyCount.textContent = historyRecords.length;
+
+  historyRecords.forEach((record) => {
+    const fragment = historyRowTemplate.content.cloneNode(true);
+    const row = fragment.querySelector('tr');
+    const radio = fragment.querySelector('input[type="radio"]');
+    const filenameCell = fragment.querySelector('.filename');
+    const statusCell = fragment.querySelector('.status');
+    const uploadedCell = fragment.querySelector('.uploaded-at');
+    const actionsCell = fragment.querySelector('.actions');
+
+    filenameCell.textContent = record.filename;
+    statusCell.textContent = record.status === 'converted' ? '已生成PDF' : '待生成';
+    statusCell.classList.add('status', record.status);
+    uploadedCell.textContent = formatDate(record.uploaded_at);
+
+    radio.checked = record.id === selectedHistoryId;
+    radio.addEventListener('change', () => {
+      selectedHistoryId = record.id;
+      highlightSelected();
+    });
+
+    const convertBtn = document.createElement('button');
+    convertBtn.textContent = record.status === 'converted' ? '重新生成' : '生成PDF';
+    convertBtn.addEventListener('click', () => convertHistory(record.id));
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.textContent = '删除';
+    deleteBtn.classList.add('danger');
+    deleteBtn.addEventListener('click', () => deleteHistory(record.id));
+
+    const templateBtn = document.createElement('button');
+    templateBtn.textContent = '保存为模板';
+    templateBtn.addEventListener('click', () => createTemplate(record.id));
+
+    actionsCell.appendChild(convertBtn);
+    if (record.download_url) {
+      const downloadLink = document.createElement('a');
+      downloadLink.href = record.download_url;
+      downloadLink.textContent = '下载PDF';
+      downloadLink.target = '_blank';
+      actionsCell.appendChild(downloadLink);
+    }
+    actionsCell.appendChild(templateBtn);
+    actionsCell.appendChild(deleteBtn);
+
+    historyBody.appendChild(fragment);
+    if (radio.checked) {
+      row.classList.add('selected');
+    }
+  });
+
+  if (!selectedHistoryId && historyRecords.length > 0) {
+    selectedHistoryId = historyRecords[0].id;
+    highlightSelected();
+  }
+}
+
+async function deleteHistory(historyId) {
+  if (!confirm('确认删除该条历史记录？')) {
+    return;
+  }
+  const response = await fetch(`/api/history/${historyId}`, {
+    method: 'DELETE',
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    showToast(result.error || '删除失败');
+    return;
+  }
+  showToast('已删除');
+  await Promise.all([refreshHistory(), refreshTemplates()]);
+  if (selectedHistoryId === historyId) {
+    selectedHistoryId = null;
+  }
+}
+
+async function createTemplate(historyId) {
+  const name = prompt('为模板输入一个名称：');
+  if (name === null) {
+    return;
+  }
+  const response = await fetch('/api/templates', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ history_id: historyId, name: name.trim() || undefined }),
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    showToast(result.error || '创建模板失败');
+    return;
+  }
+  showToast('模板已保存');
+  await refreshTemplates();
+}
+
+async function refreshTemplates() {
+  const response = await fetch('/api/templates');
+  templateRecords = await response.json();
+  renderTemplates();
+}
+
+function renderTemplates() {
+  templateList.innerHTML = '';
+  templateCount.textContent = templateRecords.length;
+
+  templateRecords.forEach((template) => {
+    const fragment = templateItemTemplate.content.cloneNode(true);
+    const item = fragment.querySelector('.template-item');
+    fragment.querySelector('.template-name').textContent = template.name;
+    fragment.querySelector('.template-date').textContent = `创建于 ${formatDate(template.created_at)}`;
+
+    const actions = fragment.querySelector('.template-actions');
+    const useBtn = document.createElement('button');
+    useBtn.textContent = '应用模板';
+    useBtn.addEventListener('click', () => useTemplate(template.id));
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.textContent = '删除';
+    deleteBtn.classList.add('danger');
+    deleteBtn.addEventListener('click', () => deleteTemplate(template.id));
+
+    actions.appendChild(useBtn);
+    if (template.download_url) {
+      const downloadLink = document.createElement('a');
+      downloadLink.href = template.download_url;
+      downloadLink.textContent = '下载模板';
+      downloadLink.target = '_blank';
+      actions.appendChild(downloadLink);
+    }
+    actions.appendChild(deleteBtn);
+
+    templateList.appendChild(fragment);
+  });
+}
+
+async function deleteTemplate(templateId) {
+  if (!confirm('确认删除该模板？')) {
+    return;
+  }
+  const response = await fetch(`/api/templates/${templateId}`, {
+    method: 'DELETE',
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    showToast(result.error || '删除模板失败');
+    return;
+  }
+  showToast('模板已删除');
+  await refreshTemplates();
+}
+
+async function useTemplate(templateId) {
+  const name = prompt('使用模板创建新文件，可修改文件名：');
+  const response = await fetch(`/api/templates/${templateId}/use`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name: name && name.trim() ? name.trim() : undefined }),
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    showToast(result.error || '应用模板失败');
+    return;
+  }
+  showToast('模板已应用，生成新的历史记录');
+  await refreshHistory();
+  selectedHistoryId = result.id;
+  highlightSelected();
+}
+
+function highlightSelected() {
+  Array.from(document.querySelectorAll('#historyBody tr')).forEach((row) => {
+    row.classList.remove('selected');
+  });
+  const selectedRadio = Array.from(document.querySelectorAll('.history-select')).find(
+    (radio) => radio.checked
+  );
+  if (selectedRadio) {
+    selectedRadio.closest('tr').classList.add('selected');
+  }
+}
+
+function toggleUploadButtons(disabled) {
+  uploadBtn.disabled = disabled;
+  generateBtn.disabled = disabled;
+}
+
+function formatDate(value) {
+  if (!value) return '-';
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+let toastTimer = null;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.remove('hidden');
+  toast.classList.add('show');
+  if (toastTimer) {
+    clearTimeout(toastTimer);
+  }
+  toastTimer = setTimeout(() => {
+    toast.classList.remove('show');
+    toastTimer = setTimeout(() => {
+      toast.classList.add('hidden');
+    }, 300);
+  }, 2600);
+}
+
+init();

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,240 @@
+:root {
+  --bg: #f7f8fa;
+  --fg: #1f2933;
+  --primary: #2563eb;
+  --accent: #10b981;
+  --border: #e2e8f0;
+  --danger: #ef4444;
+  --muted: #64748b;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header {
+  padding: 2.5rem 1.5rem 1rem;
+  text-align: center;
+  background: white;
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.08);
+}
+
+header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+header p {
+  color: var(--muted);
+  margin: 0.5rem 0 0;
+}
+
+main {
+  max-width: 1100px;
+  margin: 2rem auto;
+  padding: 0 1.5rem 3rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.upload-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+input[type="file"] {
+  flex: 1 1 260px;
+}
+
+button {
+  border: none;
+  background: var(--primary);
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+  font-weight: 600;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.accent {
+  background: var(--accent);
+}
+
+button.danger {
+  background: var(--danger);
+}
+
+.hint {
+  margin-top: 0.75rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 0.5rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.status {
+  font-weight: 600;
+}
+
+.status.converted {
+  color: var(--accent);
+}
+
+.status.uploaded {
+  color: var(--primary);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.actions a {
+  text-decoration: none;
+  background: transparent;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.template-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.template-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.template-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.template-meta span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.template-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 40px;
+  transform: translateX(-50%);
+  background: rgba(17, 24, 39, 0.92);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translate(-50%, -8px);
+}
+
+.toast.hidden {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  main {
+    margin: 1.5rem auto;
+  }
+
+  header h1 {
+    font-size: 1.6rem;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  button {
+    width: 100%;
+  }
+}
+
+#historyBody tr.selected {
+  background: rgba(37, 99, 235, 0.08);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>智能PDF转换助手</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>智能PDF转换助手</h1>
+      <p>将图表、合同、报告等文件一键生成PDF，管理历史记录与模板。</p>
+    </header>
+
+    <main>
+      <section class="card">
+        <h2>上传文件</h2>
+        <div class="upload-controls">
+          <input
+            type="file"
+            id="fileInput"
+            accept=".docx,.xlsx,.xlsm,.pptx,.txt,.csv"
+          />
+          <button id="uploadBtn">上传文件</button>
+          <button id="generateBtn" class="accent">一键生成PDF</button>
+        </div>
+        <p class="hint">
+          支持 docx、xlsx、xlsm、pptx、txt、csv 等格式，上传后可随时转换。
+        </p>
+      </section>
+
+      <section class="card" id="historySection">
+        <div class="section-header">
+          <h2>历史记录</h2>
+          <span id="historyCount" class="badge">0</span>
+        </div>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th></th>
+                <th>文件名</th>
+                <th>状态</th>
+                <th>上传时间</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody id="historyBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card" id="templateSection">
+        <div class="section-header">
+          <h2>模板中心</h2>
+          <span id="templateCount" class="badge">0</span>
+        </div>
+        <ul id="templateList" class="template-list"></ul>
+      </section>
+    </main>
+
+    <template id="historyRowTemplate">
+      <tr>
+        <td>
+          <input type="radio" name="historySelect" class="history-select" />
+        </td>
+        <td class="filename"></td>
+        <td class="status"></td>
+        <td class="uploaded-at"></td>
+        <td class="actions"></td>
+      </tr>
+    </template>
+
+    <template id="templateItemTemplate">
+      <li class="template-item">
+        <div class="template-meta">
+          <strong class="template-name"></strong>
+          <span class="template-date"></span>
+        </div>
+        <div class="template-actions"></div>
+      </li>
+    </template>
+
+    <div id="toast" class="toast hidden"></div>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build a Flask backend that stores uploads, generates PDFs, and exposes history and template endpoints
- implement converters for docx, spreadsheet, presentation, and text-based files
- add a single-page interface for uploading, one-click generation, history management, and template reuse

## Testing
- python -m compileall app.py converters.py

------
https://chatgpt.com/codex/tasks/task_e_68cc311cbc088327bfacf75edd42997c